### PR TITLE
Don't render the table body until containerRef is set.

### DIFF
--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,1 @@
+test-profiler/dist/

--- a/lib/load.php
+++ b/lib/load.php
@@ -13,6 +13,7 @@ define( 'IS_GUTENBERG_PLUGIN', true );
 
 require_once __DIR__ . '/init.php';
 require_once __DIR__ . '/upgrade.php';
+require_once __DIR__ . '/test-profiler/index.php';
 
 /**
  * Checks whether the Gutenberg experiment is enabled.

--- a/lib/test-profiler/index.php
+++ b/lib/test-profiler/index.php
@@ -1,31 +1,49 @@
 <?php
-
+/**
+ * Add custom admin menu page
+ */
 add_action('admin_menu', function () {
-    add_menu_page(
-        'My Custom Page',      // Page title
-        'Profile Test Page',         // Menu title
-        'manage_options',      // Capability
-        'my-custom-page',      // Menu slug
-        'my_custom_page_html', // Callback function
-        'dashicons-admin-generic', // Icon (optional)
-        20                     // Position
-    );
+	add_menu_page(
+		'My Custom Page',
+		'Profile Test Page',
+		'manage_options',
+		'my-custom-page',
+		'my_custom_page_html',
+		'dashicons-admin-generic',
+		20
+	);
 });
 
+/**
+ * Render the custom admin page HTML
+ */
 function my_custom_page_html() {
-    if (!current_user_can('manage_options')) {
-        return;
-    }
-    
-    echo '<div class="wrap">';
-    echo '<h1>My Custom Admin Page</h1>';
-    echo '<div id="root"></div>';
-    echo '</div>';
+	// Check user capabilities
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	// Output admin page markup
+	echo '<div class="wrap">';
+	echo '<h1>My Custom Admin Page</h1>';
+	echo '<div id="root"></div>';
+	echo '</div>';
 }
 
-add_action('admin_enqueue_scripts', function ($hook) {
-    if ($hook !== 'toplevel_page_my-custom-page') {
-        return;
-    }
-    wp_enqueue_script('my-custom-js', plugin_dir_url(__FILE__) . '/dist/script.umd.js', [], false, true);
+/**
+ * Enqueue scripts for the custom admin page
+ */
+add_action('admin_enqueue_scripts', function ( $hook ) {
+	// Only load script on our specific page
+	if ( $hook !== 'toplevel_page_my-custom-page' ) {
+		return;
+	}
+
+	wp_enqueue_script(
+		'my-custom-js',
+		plugin_dir_url( __FILE__ ) . '/dist/script.umd.js',
+		[],
+		false,
+		true
+	);
 });

--- a/lib/test-profiler/index.php
+++ b/lib/test-profiler/index.php
@@ -1,0 +1,31 @@
+<?php
+
+add_action('admin_menu', function () {
+    add_menu_page(
+        'My Custom Page',      // Page title
+        'Profile Test Page',         // Menu title
+        'manage_options',      // Capability
+        'my-custom-page',      // Menu slug
+        'my_custom_page_html', // Callback function
+        'dashicons-admin-generic', // Icon (optional)
+        20                     // Position
+    );
+});
+
+function my_custom_page_html() {
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+    
+    echo '<div class="wrap">';
+    echo '<h1>My Custom Admin Page</h1>';
+    echo '<div id="root"></div>';
+    echo '</div>';
+}
+
+add_action('admin_enqueue_scripts', function ($hook) {
+    if ($hook !== 'toplevel_page_my-custom-page') {
+        return;
+    }
+    wp_enqueue_script('my-custom-js', plugin_dir_url(__FILE__) . '/dist/script.umd.js', [], false, true);
+});

--- a/lib/test-profiler/index.php
+++ b/lib/test-profiler/index.php
@@ -2,48 +2,58 @@
 /**
  * Add custom admin menu page
  */
-add_action('admin_menu', function () {
-	add_menu_page(
-		'My Custom Page',
-		'Profile Test Page',
-		'manage_options',
-		'my-custom-page',
-		'my_custom_page_html',
-		'dashicons-admin-generic',
-		20
-	);
-});
-
-/**
- * Render the custom admin page HTML
- */
-function my_custom_page_html() {
-	// Check user capabilities
-	if ( ! current_user_can( 'manage_options' ) ) {
-		return;
+add_action(
+	'admin_menu',
+	function () {
+		add_menu_page(
+			'My Custom Page',
+			'Profile Test Page',
+			'manage_options',
+			'my-custom-page',
+			'test_my_custom_page_html',
+			'dashicons-admin-generic',
+			20
+		);
 	}
+);
 
-	// Output admin page markup
-	echo '<div class="wrap">';
-	echo '<h1>My Custom Admin Page</h1>';
-	echo '<div id="root"></div>';
-	echo '</div>';
+
+if ( ! function_exists( 'test_my_custom_page_html' ) ) {
+	/**
+	 * Render the custom admin page HTML
+	 */
+	function test_my_custom_page_html() {
+		// Check user capabilities
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Output admin page markup
+		echo '<div class="wrap">';
+		echo '<h1>My Custom Admin Page</h1>';
+		echo '<div id="root"></div>';
+		echo '</div>';
+	}
 }
+
 
 /**
  * Enqueue scripts for the custom admin page
  */
-add_action('admin_enqueue_scripts', function ( $hook ) {
-	// Only load script on our specific page
-	if ( $hook !== 'toplevel_page_my-custom-page' ) {
-		return;
-	}
+add_action(
+	'admin_enqueue_scripts',
+	function ( $hook ) {
+		// Only load script on our specific page
+		if ( 'toplevel_page_my-custom-page' !== $hook ) {
+			return;
+		}
 
-	wp_enqueue_script(
-		'my-custom-js',
-		plugin_dir_url( __FILE__ ) . '/dist/script.umd.js',
-		[],
-		false,
-		true
-	);
-});
+		wp_enqueue_script(
+			'my-custom-js',
+			plugin_dir_url( __FILE__ ) . '/dist/script.umd.js',
+			array(),
+			false,
+			true
+		);
+	}
+);

--- a/lib/test-profiler/package-lock.json
+++ b/lib/test-profiler/package-lock.json
@@ -1,0 +1,25 @@
+{
+	"name": "test-profiler",
+	"version": "1.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "test-profiler",
+			"version": "1.0.0",
+			"license": "ISC",
+			"dependencies": {
+				"process": "^0.11.10"
+			}
+		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		}
+	}
+}

--- a/lib/test-profiler/package.json
+++ b/lib/test-profiler/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "test-profiler",
+	"version": "1.0.0",
+	"main": "vite.config.js",
+	"scripts": {
+		"build": "npx vite build",
+		"watch": "npx vite build --watch"
+	},
+	"author": "",
+	"license": "ISC",
+	"description": "",
+	"dependencies": {
+		"process": "^0.11.10"
+	}
+}

--- a/lib/test-profiler/script.jsx
+++ b/lib/test-profiler/script.jsx
@@ -1,0 +1,209 @@
+// src/Example.jsx
+import { Button, Icon } from '@wordpress/components';
+import { DataViews } from '../../packages/dataviews';
+import { edit } from '@wordpress/icons';
+import React, { Profiler } from 'react';
+
+// --- Mock for i18n ---
+// In a real WP environment, this comes from '@wordpress/i18n' and handles translations
+const __ = ( text, domain ) => {
+	// console.log(`i18n: [${domain || 'default'}] "${text}"`); // Optional: log translation calls
+	return text;
+};
+// --- End Mock ---
+
+
+console.log('ok')
+const generateFakeData = ( count ) => {
+	const statuses = [
+		'draft',
+		'future',
+		'‰pending',
+		'private',
+		'publish',
+		'trash',
+	];
+	return Array.from( { length: count }, ( _, i ) => ( {
+		id: i + 1,
+		title: `Title ${ i + 1 }`,
+		author: i % 2 === 0 ? 'Admin' : 'User',
+		date: new Date( 2023, i % 12, ( i % 28 ) + 1 ).toISOString(),
+		status: statuses[ i % statuses.length ],
+	} ) );
+};
+
+// Your onRender callback for the Profiler
+const onRender = (
+	id,
+	phase,
+	actualDuration,
+	baseDuration,
+	startTime,
+	commitTime
+) => {
+	console.log( {
+		id, // the "id" prop of the Profiler tree that has just committed
+		phase, // "mount" (if the tree just mounted) or "update" (if it re-rendered)
+		actualDuration, // time spent rendering the committed update
+		baseDuration, // estimated time to render the entire subtree without memoization
+		startTime, // when React began rendering this update
+		commitTime, // when React committed this update
+		// interactions // Set of interactions belonging to this update
+	} );
+};
+
+const data = generateFakeData( 1000 ); // Using 1000 items as per your example
+
+const Example = () => {
+	// State for view - important for DataViews to be interactive
+	const [ view, setView ] = React.useState( {
+		type: 'table',
+		search: '',
+		filters: [],
+		page: 1,
+		perPage: 1000, // Increased perPage slightly
+		sort: {
+			field: 'date',
+			direction: 'desc',
+		},
+		fields: [ 'author', 'status' ],
+		// No need for titleField here, it's inferred or set in fields
+		// titleField: "title",
+		// Removed layout: {}, use defaultLayouts instead if needed for specific view types
+	} );
+
+	// State for pagination - This should update based on view changes
+	const [ paginationInfo, setPaginationInfo ] = React.useState( {
+		totalItems: data.length, // Use totalItems standardly
+		totalPages: Math.ceil( data.length / view.perPage ),
+	} );
+
+	// Update pagination when view (especially perPage) changes
+	React.useEffect( () => {
+		setPaginationInfo( ( prev ) => ( {
+			...prev,
+			totalPages: Math.ceil( data.length / view.perPage ),
+		} ) );
+	}, [ view.perPage ] );
+
+	const STATUSES = [
+		{ value: 'draft', label: __( 'Draft' ) },
+		{ value: 'future', label: __( 'Scheduled' ) },
+		{ value: 'pending', label: __( 'Pending Review' ) },
+		{ value: 'private', label: __( 'Private' ) },
+		{ value: 'publish', label: __( 'Published' ) },
+		{ value: 'trash', label: __( 'Trash' ) },
+	];
+
+	const fields = [
+		{
+			id: 'title',
+			header: __( 'Title' ), // Use header for column title
+			enableHiding: false,
+			// Default rendering works for simple properties
+		},
+		{
+			id: 'date',
+			header: __( 'Date' ),
+			render: ( { item } ) => (
+				<time dateTime={ item.date }>
+					{ new Date( item.date ).toLocaleDateString() }
+				</time>
+			),
+		},
+		{
+			id: 'author',
+			header: __( 'Author' ),
+			render: ( { item } ) => <a href="#">{ item.author }</a>,
+			elements: [
+				// Used for filtering usually
+				{ value: 'Admin', label: 'Admin' },
+				{ value: 'User', label: 'User' },
+			],
+			filterBy: {
+				// Define how filtering works for this field
+				type: 'enum',
+				operators: [ 'is', 'isNot' ],
+			},
+			enableSorting: true, // Let's allow sorting by author
+		},
+		{
+			id: 'status',
+			header: __( 'Status' ),
+			// Render based on STATUSES lookup
+			render: ( { item } ) =>
+				STATUSES.find( ( { value } ) => value === item.status )
+					?.label ?? item.status,
+			elements: STATUSES, // Provide elements for filtering
+			filterBy: {
+				// Define how filtering works for this field
+				type: 'enum',
+				operators: [ 'isAny', 'isNone' ], // Common operators for multi-select
+			},
+			enableSorting: false, // Keep sorting disabled for status maybe
+		},
+	];
+
+	// Callback when view state changes (sorting, filtering, pagination)
+	const onChangeView = ( newView ) => {
+		console.log( 'View changing:', newView );
+		// You MUST update the state for the component to react
+		setView( newView );
+	};
+
+	const actions = [
+		{
+			id: 'edit',
+			label: __( 'Edit' ),
+			icon: edit, // Pass the icon component/data directly
+			callback: ( items ) => console.log( 'Editing:', items ),
+			supportsBulk: true,
+			isEligible: () => true,
+		},
+	];
+
+	// Data might need pagination/sorting/filtering applied *before* passing
+	// For simplicity here, DataViews might handle some of this internally based on `view` prop,
+	// but often you'd apply it here based on `view.page`, `view.perPage`, `view.sort`, `view.filters`
+	// Example (basic pagination):
+	const startIndex = ( view.page - 1 ) * view.perPage;
+	const endIndex = startIndex + view.perPage;
+	const paginatedData = data.slice( startIndex, endIndex );
+	// Add sorting/filtering logic here if needed
+
+	return (
+		// Wrap the part you want to profile
+		<Profiler id="DataViewsComponent" onRender={ onRender }>
+			<div style={ { padding: '20px' } }>
+				{ ' ' }
+				{ /* Add some padding */ }
+				<h1>DataViews Profiler Test</h1>
+				<DataViews
+					data={ paginatedData } // Pass potentially filtered/sorted/paginated data
+					fields={ fields }
+					view={ view } // Pass the state variable
+					onChangeView={ onChangeView } // Pass the state setter callback
+					actions={ actions }
+					paginationInfo={ paginationInfo } // Pass pagination state
+					// onSelectionChange={(selectedItems) => console.log('Selection:', selectedItems)} // Optional: handle selection
+				/>
+			</div>
+		</Profiler>
+	);
+};
+
+// Removed the DOMContentLoaded logic as it's handled by src/main.jsx
+
+
+if (typeof window !== 'undefined') {
+    document.addEventListener("DOMContentLoaded", function () {
+        const container = document.getElementById("root");
+        if (container) {
+            import('@wordpress/element').then(({ createRoot }) => {
+                const root = createRoot(container);
+
+                root.render(<Example />);
+            });
+        }
+    });
+}

--- a/lib/test-profiler/script.jsx
+++ b/lib/test-profiler/script.jsx
@@ -1,5 +1,4 @@
 // src/Example.jsx
-import { Button, Icon } from '@wordpress/components';
 import { DataViews } from '../../packages/dataviews';
 import { edit } from '@wordpress/icons';
 import React, { Profiler } from 'react';
@@ -65,7 +64,7 @@ const onRender = (
 	});
 };
 
-const data = generateFakeData( 1000 );
+const data = generateFakeData( 50 );
 
 const Example = () => {
 

--- a/lib/test-profiler/vite.config.js
+++ b/lib/test-profiler/vite.config.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import process from 'process';
+
+export default {
+	build: {
+		lib: {
+			entry: 'script.jsx',
+			name: 'MyAdminLibrary',
+			fileName: 'script',
+			formats: [ 'umd' ],
+		},
+		outDir: 'dist',
+		minify: false,
+		sourcemap: true,
+		rollupOptions: {
+			external: [ 'process' ], // Ensure `process` is handled as external
+			output: {
+				globals: {
+					process: 'process', // Define `process` globally in the UMD bundle
+				},
+			},
+		},
+	},
+	server: {
+		watch: {
+			usePolling: true, // useful for local development with certain setups (e.g., Docker)
+		},
+	},
+	define: {
+		process: JSON.stringify( process ), // Inject process polyfill
+		'process.env.NODE_ENV': JSON.stringify( 'development' ),
+	},
+	optimizeDeps: {
+		include: [
+			'path-to-your-local-package', // include your local packages here
+		],
+	},
+};

--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -29,7 +29,7 @@ type DataViewsContextType< Item > = {
 	getItemLevel?: ( item: Item ) => number;
 	onClickItem?: ( item: Item ) => void;
 	isItemClickable: ( item: Item ) => boolean;
-	containerWidth: number;
+	containerWidth: number | undefined;
 };
 
 const DataViewsContext = createContext< DataViewsContextType< any > >( {

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -76,7 +76,6 @@ export default function DataViews< Item >( {
 	isItemClickable = defaultIsItemClickable,
 	header,
 }: DataViewsProps< Item > ) {
-	console.log( 'Rendered <DataViews>');
 	const [ containerWidth, setContainerWidth ] = useState<
 		number | undefined
 	>( undefined );
@@ -170,8 +169,12 @@ export default function DataViews< Item >( {
 					</HStack>
 				</HStack>
 				{ isShowingFilter && <DataViewsFilters /> }
-				{ containerWidth === undefined ? '' : <DataViewsLayout /> }
-				<DataViewsFooter />
+				{ containerWidth === undefined ? null : (
+					<>
+						<DataViewsLayout />
+						<DataViewsFooter />
+					</>
+				) }
 			</div>
 		</DataViewsContext.Provider>
 	);

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -76,8 +76,10 @@ export default function DataViews< Item >( {
 	isItemClickable = defaultIsItemClickable,
 	header,
 }: DataViewsProps< Item > ) {
-	console.log( 'Rendered <DataViews>')
-	const [ containerWidth, setContainerWidth ] = useState( undefined );
+	console.log( 'Rendered <DataViews>');
+	const [ containerWidth, setContainerWidth ] = useState<
+		number | undefined
+	>( undefined );
 	const containerRef = useResizeObserver(
 		( resizeObserverEntries: any ) => {
 			setContainerWidth(

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -76,7 +76,8 @@ export default function DataViews< Item >( {
 	isItemClickable = defaultIsItemClickable,
 	header,
 }: DataViewsProps< Item > ) {
-	const [ containerWidth, setContainerWidth ] = useState( 0 );
+	console.log( 'Rendered <DataViews>')
+	const [ containerWidth, setContainerWidth ] = useState( undefined );
 	const containerRef = useResizeObserver(
 		( resizeObserverEntries: any ) => {
 			setContainerWidth(
@@ -167,7 +168,7 @@ export default function DataViews< Item >( {
 					</HStack>
 				</HStack>
 				{ isShowingFilter && <DataViewsFilters /> }
-				<DataViewsLayout />
+				{ containerWidth === undefined ? '' : <DataViewsLayout /> }
 				<DataViewsFooter />
 			</div>
 		</DataViewsContext.Provider>

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -36,7 +36,7 @@ const BREAKPOINTS = {
 function useViewPortBreakpoint() {
 	const containerWidth = useContext( DataViewsContext ).containerWidth;
 	for ( const [ key, value ] of Object.entries( BREAKPOINTS ) ) {
-		if ( containerWidth >= value ) {
+		if ( containerWidth !== undefined && containerWidth >= value ) {
 			return key;
 		}
 	}


### PR DESCRIPTION
> [!Warning]
> Changes in `/lib` need to be deleted first and is not part of this review.

## Problem

When `<DataViews`> loads, `containerWidth` is set to `0`. The reference doesn't exist yet. React continues to render the children, which includes `<DataViewsLayout>` which renders `<DataViews>`.

Once the ref is set, `useResizeObserver` fires and updates the `containerWidth` triggering a second render. 

Since we know that value will update, it makes sense to wait for that value to be updated first.

## Results

_Tested using 500 rows_

| Before | After |
|--------|--------| 
| <img width="943" alt="Screenshot 2025-03-31 at 10 35 24 AM" src="https://github.com/user-attachments/assets/1d28a5a8-5525-4b50-8e6a-5592db7364a0" /> | <img width="942" alt="Screenshot 2025-03-31 at 10 34 21 AM" src="https://github.com/user-attachments/assets/4f956d94-0ac7-44e3-a960-896624ee3d47" /> |

We still see two renders. The first one is much quicker, rendering only the filters. The second takes about the same time as the first render in the before state. Ultimately, we eliminate the overhead of a full re-render. 

This results in a `~40%` decrease in initial loading time.

## Considerations

Since we delay rendering the table body, we get two side effects:
- The filters above the table load quicker.
- The table rows appear after.

| Before | After |
|--------|--------|
| ![Screen Capture on 2025-03-31 at 10-54-02](https://github.com/user-attachments/assets/ef5b565a-fa35-43be-8034-d44d8de95aa6) | ![Screen Capture on 2025-03-31 at 10-53-17](https://github.com/user-attachments/assets/23d15317-c610-49e9-a7e8-398b4aa1a19e) | 

I think this is a net positive. The question is whether we should provide a loading state.

For Example: (Excuse the lack of styles)

<img src="https://github.com/user-attachments/assets/fda0aa62-0124-4a52-b796-990e10350c95" width="300">

**I'm not certain we need to add the loading state in now. I could be convinced otherwise though.**


## How To Test
1. cd to lib/test-profiler
2. run npm run watch
3. Visit http://localhost:8888/wp-admin/admin.php?page=my-custom-page





